### PR TITLE
[PAGOPA-2017] fix: Add `id` to IOMessage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,8 +270,8 @@
                     <appServicePlanName>java-functions-app-service-plan</appServicePlanName>
                     <region>westus</region>
                     <runtime>
-                        <os>windows</os>
-                        <javaVersion>17</javaVersion>
+                        <os>linux</os>
+                        <javaVersion>${java.version}</javaVersion>
                     </runtime>
                 </configuration>
                 <executions>

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/entity/message/IOMessage.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/entity/message/IOMessage.java
@@ -8,7 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class IOMessage {
-
+    String id;
     String messageId;
     String eventId;
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/service/impl/ReceiptToIOServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/service/impl/ReceiptToIOServiceImpl.java
@@ -252,6 +252,7 @@ public class ReceiptToIOServiceImpl implements ReceiptToIOService {
         IOMessageData ioMessageData = receipt.getIoMessageData();
         String messageId = userType.equals(UserType.DEBTOR) ? ioMessageData.getIdMessageDebtor() : ioMessageData.getIdMessagePayer();
         return IOMessage.builder()
+                .id(messageId)
                 .messageId(messageId)
                 .eventId(receipt.getEventId())
                 .build();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- add `id` to `IOMessage` entity and set `messageId` as `id` value 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

From version 4.x `Item ID` is no longer auto populated in the Extension, so `null` values are not allowed.

https://learn.microsoft.com/en-us/azure/azure-functions/migrate-cosmos-db-version-3-version-4?tabs=in-process&pivots=programming-language-java#changes-to-item-id-generation

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.