### PR TITLE
chore: [PAGOPA-3667] Query optimization

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -53,16 +53,11 @@ jobs:
       - name: Run Integration Tests
         shell: bash
         env:
-          CUCUMBER_PUBLISH_TOKEN_ENV: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
-          RECEIPTS_STORAGE_CONN_STRING_ENV: ${{ secrets.RECEIPTS_STORAGE_CONN_STRING }}
-          RECEIPTS_COSMOS_CONN_STRING_ENV: ${{ secrets.RECEIPTS_COSMOS_CONN_STRING }}
-          TOKENIZER_API_KEY_ENV: ${{ secrets.TOKENIZER_API_KEY }}
+          CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
+          RECEIPTS_STORAGE_CONN_STRING: ${{ secrets.RECEIPTS_STORAGE_CONN_STRING }}
+          RECEIPTS_COSMOS_CONN_STRING: ${{ secrets.RECEIPTS_COSMOS_CONN_STRING }}
+          TOKENIZER_API_KEY: ${{ secrets.TOKENIZER_API_KEY }}
         run: |
-          export CUCUMBER_PUBLISH_TOKEN="$CUCUMBER_PUBLISH_TOKEN_ENV"
-          export RECEIPTS_STORAGE_CONN_STRING="$RECEIPTS_STORAGE_CONN_STRING_ENV"
-          export RECEIPTS_COSMOS_CONN_STRING="$RECEIPTS_COSMOS_CONN_STRING_ENV"
-          export TOKENIZER_API_KEY="$TOKENIZER_API_KEY_ENV"
-          
           cd ./integration-test
           chmod +x ./run_integration_test.sh
           ./run_integration_test.sh ${{( github.event.inputs == null && 'uat') || inputs.environment }}

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfnotifier
 description: Microservice description
 type: application
-version: 0.117.0
-appVersion: 0.15.5
+version: 0.118.0
+appVersion: 0.15.5-1-PAGOPA-3625-query-optimization
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfnotifier
 description: Microservice description
 type: application
-version: 0.119.0
-appVersion: 0.15.6
+version: 0.120.0
+appVersion: 0.15.6-1-PAGOPA-3625-query-optimization
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-receipt-pdf-notifier"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-notifier
-    tag: "0.15.6"
+    tag: "0.15.6-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-receipt-pdf-notifier"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-notifier
-    tag: "0.15.5"
+    tag: "0.15.5-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-receipt-pdf-notifier"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-notifier
-    tag: "0.15.6"
+    tag: "0.15.6-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-receipt-pdf-notifier"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-notifier
-    tag: "0.15.5"
+    tag: "0.15.5-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-receipt-pdf-notifier"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-notifier
-    tag: "0.15.6"
+    tag: "0.15.6-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-receipt-pdf-notifier"
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-notifier
-    tag: "0.15.5"
+    tag: "0.15.5-1-PAGOPA-3625-query-optimization"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/integration-test/src/step_definitions/receipt_pdf_notifier_step.js
+++ b/integration-test/src/step_definitions/receipt_pdf_notifier_step.js
@@ -58,7 +58,6 @@ Then('the receipt has not the status {string}', function (targetStatus) {
 });
 
 Then('the receipt has the status {string}', function (targetStatus) {
-    console.log("Receipt", this.responseToCheck.resources[0].id, this.responseToCheck.resources[0].status);
     assert.strictEqual(this.responseToCheck.resources[0].status, targetStatus);
 });
 
@@ -68,7 +67,6 @@ Given('a random receipt with id {string} enqueued on notification error queue', 
     await deleteDocumentFromReceiptsDatastore(this.receiptId, this.receiptId);
 
     let event = createReceiptForError(this.receiptId, this.fiscalCodeToken);
-    console.log("Enqueuing event on notification error queue:", event);
     await putMessageOnQueue(event);
 });
 
@@ -101,7 +99,6 @@ Then('the cart receipt has not the status {string}', function (targetStatus) {
 });
 
 Then('the cart receipt has the status {string}', function (targetStatus) {
-    console.log("Cart receipt", this.responseToCheck.resources[0].id, this.responseToCheck.resources[0].status);
     assert.strictEqual(this.responseToCheck.resources[0].status, targetStatus);
 });
 
@@ -111,7 +108,6 @@ Given('a random cart receipt with id {string} enqueued on notification error que
     await deleteDocumentFromCartReceiptsDatastore(this.cartReceiptId, this.cartReceiptId);
 
     let event = createCartReceiptForError(this.cartReceiptId, this.fiscalCodeToken);
-    console.log("Enqueuing event on notification error queue for cart:", event);
     await putMessageOnCartQueue(event);
 });
 

--- a/integration-test/src/step_definitions/tokenizer_client.js
+++ b/integration-test/src/step_definitions/tokenizer_client.js
@@ -1,14 +1,14 @@
 const axios = require("axios");
 
-const tokenizer_url = process.env.TOKENIZER_URL;
+const tokenizerClient = axios.create({
+	baseURL: process.env.TOKENIZER_URL,
+	headers: {
+		'x-api-key': process.env.TOKENIZER_API_KEY || ""
+	}
+});
 
 async function createToken(fiscalCode) {
-    let token_api_key = process.env.TOKENIZER_API_KEY;
-  	let headers = {
-  	  "x-api-key": token_api_key
-  	};
-
-  	return await axios.put(tokenizer_url, { "pii": fiscalCode }, { headers })
+  	return await tokenizerClient.put("", { "pii": fiscalCode })
   		.then(res => {
 			console.log("tokenizer response", res.status, res.data);
   			return res.data;

--- a/integration-test/src/step_definitions/tokenizer_client.js
+++ b/integration-test/src/step_definitions/tokenizer_client.js
@@ -10,11 +10,9 @@ const tokenizerClient = axios.create({
 async function createToken(fiscalCode) {
   	return await tokenizerClient.put("", { "pii": fiscalCode })
   		.then(res => {
-			console.log("tokenizer response", res.status, res.data);
   			return res.data;
   		})
   		.catch(error => {
-			console.log("tokenizer error", error.response.status, error.response.data);
   			return error.response;
   		});
 

--- a/integration-test/src/step_definitions/tokenizer_client.js
+++ b/integration-test/src/step_definitions/tokenizer_client.js
@@ -10,9 +10,11 @@ async function createToken(fiscalCode) {
 
   	return await axios.put(tokenizer_url, { "pii": fiscalCode }, { headers })
   		.then(res => {
+			console.log("tokenizer response", res.status, res.data);
   			return res.data;
   		})
   		.catch(error => {
+			console.log("tokenizer error", error.response.status, error.response.data);
   			return error.response;
   		});
 

--- a/openapi/openapi-spec.yml
+++ b/openapi/openapi-spec.yml
@@ -1,2 +1,2 @@
 info:
-  version: 0.15.6
+  version: 0.15.6-1-PAGOPA-3625-query-optimization

--- a/openapi/openapi-spec.yml
+++ b/openapi/openapi-spec.yml
@@ -1,2 +1,2 @@
 info:
-  version: 0.15.5
+  version: 0.15.5-1-PAGOPA-3625-query-optimization

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.project</groupId>
     <artifactId>pagopa-receipt-pdf-notifier</artifactId>
-    <version>0.15.5</version>
+    <version>0.15.5-1-PAGOPA-3625-query-optimization</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-notifier</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.project</groupId>
     <artifactId>pagopa-receipt-pdf-notifier</artifactId>
-    <version>0.15.6</version>
+    <version>0.15.6-1-PAGOPA-3625-query-optimization</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-notifier</name>

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/ReceiptCosmosClient.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/ReceiptCosmosClient.java
@@ -2,14 +2,21 @@ package it.gov.pagopa.receipt.pdf.notifier.client;
 
 
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.IOMessage;
-import it.gov.pagopa.receipt.pdf.notifier.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.notifier.exception.IoMessageNotFoundException;
-import it.gov.pagopa.receipt.pdf.notifier.exception.ReceiptNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.model.enumeration.UserType;
 
+/**
+ * Client for the CosmosDB database
+ */
 public interface ReceiptCosmosClient {
 
-    Receipt getReceiptDocument(String receiptId) throws ReceiptNotFoundException;
-
+    /**
+     * Retrieve io message document from CosmosDB database with the provided event id and user type
+     *
+     * @param eventId  Receipt event id
+     * @param userType Recipient of the IO message
+     * @return io message document
+     * @throws IoMessageNotFoundException in case no receipt has been found with the given eventId and user type
+     */
     IOMessage findIOMessageWithEventIdAndUserType(String eventId, UserType userType) throws IoMessageNotFoundException;
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
@@ -5,11 +5,15 @@ import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.client.CartReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.CartIOMessage;
 import it.gov.pagopa.receipt.pdf.notifier.exception.CartIoMessageNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.model.enumeration.UserType;
+
+import java.util.Arrays;
 
 /**
  * {@inheritDoc}
@@ -58,24 +62,38 @@ public class CartReceiptCosmosClientImpl implements CartReceiptCosmosClient {
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerMessageId);
 
         //Build query
-        String query;
-        if (UserType.PAYER.equals(userType)) {
-            query = String.format(
-                    "SELECT * FROM c WHERE  c.cartId = '%s' AND c.userType = '%s'",
-                    cartId, userType);
-        } else {
-            query = String.format(
-                    "SELECT * FROM c WHERE  c.cartId = '%s' AND c.eventId = '%s' AND c.userType = '%s'",
-                    cartId, eventId, userType);
-        }
+        SqlQuerySpec querySpec = buildQuery(cartId, eventId, userType);
 
         //Query the container
         CosmosPagedIterable<CartIOMessage> queryResponse = cosmosContainer
-                .queryItems(query, new CosmosQueryRequestOptions(), CartIOMessage.class);
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), CartIOMessage.class);
 
         if (queryResponse.iterator().hasNext()) {
             return queryResponse.iterator().next();
         }
         throw new CartIoMessageNotFoundException("Document not found in the defined container");
+    }
+
+    private SqlQuerySpec buildQuery(String cartId, String eventId, UserType userType) {
+        SqlQuerySpec querySpec;
+        if (UserType.PAYER.equals(userType)) {
+            querySpec = new SqlQuerySpec(
+                    "SELECT * FROM c WHERE c.cartId = @cartId AND c.userType = @userType ",
+                    Arrays.asList(
+                            new SqlParameter("@cartId", cartId),
+                            new SqlParameter("@userType", userType)
+                    )
+            );
+        } else {
+            querySpec = new SqlQuerySpec(
+                    "SELECT * FROM c WHERE c.cartId = @cartId AND c.eventId = @eventId AND c.userType = @userType ",
+                    Arrays.asList(
+                            new SqlParameter("@cartId", cartId),
+                            new SqlParameter("@eventId", eventId),
+                            new SqlParameter("@userType", userType)
+                    )
+            );
+        }
+        return querySpec;
     }
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
@@ -19,8 +19,6 @@ import java.util.Arrays;
  */
 public class CartReceiptCosmosClientImpl implements CartReceiptCosmosClient {
 
-    private static CartReceiptCosmosClientImpl instance;
-
     private final CosmosContainer cartIoMessageContainer;
 
     @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
@@ -45,11 +43,15 @@ public class CartReceiptCosmosClientImpl implements CartReceiptCosmosClient {
     }
 
     public static CartReceiptCosmosClientImpl getInstance() {
-        if (instance == null) {
-            instance = new CartReceiptCosmosClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final CartReceiptCosmosClientImpl INSTANCE = new CartReceiptCosmosClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
@@ -5,6 +5,7 @@ import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
@@ -63,10 +64,12 @@ public class CartReceiptCosmosClientImpl implements CartReceiptCosmosClient {
 
         //Build query
         SqlQuerySpec querySpec = buildQuery(cartId, eventId, userType);
+        CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
+        options.setPartitionKey(new PartitionKey(cartId));
 
         //Query the container
         CosmosPagedIterable<CartIOMessage> queryResponse = cosmosContainer
-                .queryItems(querySpec, new CosmosQueryRequestOptions(), CartIOMessage.class);
+                .queryItems(querySpec, options, CartIOMessage.class);
 
         if (queryResponse.iterator().hasNext()) {
             return queryResponse.iterator().next();

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImpl.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -8,7 +7,6 @@ import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
-import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.client.CartReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.CartIOMessage;
 import it.gov.pagopa.receipt.pdf.notifier.exception.CartIoMessageNotFoundException;
@@ -23,23 +21,27 @@ public class CartReceiptCosmosClientImpl implements CartReceiptCosmosClient {
 
     private static CartReceiptCosmosClientImpl instance;
 
-    private final String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
-    private final String containerMessageId = System.getenv("COSMOS_CART_RECEIPT_MESSAGE_CONTAINER_NAME");
+    private final CosmosContainer cartIoMessageContainer;
 
-    private final CosmosClient cosmosClient;
-
+    @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
     private CartReceiptCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_RECEIPT_KEY");
         String serviceEndpoint = System.getenv("COSMOS_RECEIPT_SERVICE_ENDPOINT");
 
-        this.cosmosClient = new CosmosClientBuilder()
+        String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
+        String containerMessageId = System.getenv("COSMOS_CART_RECEIPT_MESSAGE_CONTAINER_NAME");
+
+        CosmosDatabase cosmosDatabase = new CosmosClientBuilder()
                 .endpoint(serviceEndpoint)
                 .key(azureKey)
-                .buildClient();
+                .buildClient()
+                .getDatabase(databaseId);
+
+        this.cartIoMessageContainer = cosmosDatabase.getContainer(containerMessageId);
     }
 
-    CartReceiptCosmosClientImpl(CosmosClient cosmosClient) {
-        this.cosmosClient = cosmosClient;
+    CartReceiptCosmosClientImpl(CosmosContainer cartIoMessageContainer) {
+        this.cartIoMessageContainer = cartIoMessageContainer;
     }
 
     public static CartReceiptCosmosClientImpl getInstance() {
@@ -59,22 +61,16 @@ public class CartReceiptCosmosClientImpl implements CartReceiptCosmosClient {
             String eventId,
             UserType userType
     ) throws CartIoMessageNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerMessageId);
-
         //Build query
         SqlQuerySpec querySpec = buildQuery(cartId, eventId, userType);
         CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
         options.setPartitionKey(new PartitionKey(cartId));
 
         //Query the container
-        CosmosPagedIterable<CartIOMessage> queryResponse = cosmosContainer
-                .queryItems(querySpec, options, CartIOMessage.class);
-
-        if (queryResponse.iterator().hasNext()) {
-            return queryResponse.iterator().next();
-        }
-        throw new CartIoMessageNotFoundException("Document not found in the defined container");
+        return cartIoMessageContainer.queryItems(querySpec, options, CartIOMessage.class)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new CartIoMessageNotFoundException("Document not found in the defined container"));
     }
 
     private SqlQuerySpec buildQuery(String cartId, String eventId, UserType userType) {

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/IOClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/IOClientImpl.java
@@ -31,15 +31,6 @@ public class IOClientImpl implements IOClient {
 
     private final HttpClient client;
 
-    private static IOClient instance = null;
-
-    public static IOClient getInstance() {
-        if (instance == null) {
-            instance = new IOClientImpl();
-        }
-        return instance;
-    }
-
     private IOClientImpl() {
         this.client = HttpClient.newBuilder()
                 .version(HttpClient.Version.HTTP_2)
@@ -48,6 +39,18 @@ public class IOClientImpl implements IOClient {
 
     IOClientImpl(HttpClient client) {
         this.client = client;
+    }
+
+    public static IOClientImpl getInstance() {
+        return SingletonHelper.INSTANCE;
+    }
+
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final IOClientImpl INSTANCE = new IOClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierCartQueueClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierCartQueueClientImpl.java
@@ -14,8 +14,6 @@ import java.time.temporal.ChronoUnit;
  */
 public class NotifierCartQueueClientImpl implements NotifierCartQueueClient {
 
-    private static NotifierCartQueueClientImpl instance;
-
     private final int cartReceiptQueueDelay = Integer.parseInt(System.getenv().getOrDefault("NOTIFIER_CART_QUEUE_DELAY", "1"));
 
     private final QueueClient queueClient;
@@ -35,18 +33,21 @@ public class NotifierCartQueueClientImpl implements NotifierCartQueueClient {
     }
 
     public static NotifierCartQueueClientImpl getInstance() {
-        if (instance == null) {
-            instance = new NotifierCartQueueClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final NotifierCartQueueClientImpl INSTANCE = new NotifierCartQueueClientImpl();
     }
 
     /**
      * {@inheritDoc}
      */
     public Response<SendMessageResult> sendMessageToQueue(String messageText) {
-
         return this.queueClient.sendMessageWithResponse(
                 messageText, Duration.of(cartReceiptQueueDelay, ChronoUnit.SECONDS),
                 null, null, null);

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierQueueClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierQueueClientImpl.java
@@ -14,8 +14,6 @@ import java.time.temporal.ChronoUnit;
  */
 public class NotifierQueueClientImpl implements NotifierQueueClient {
 
-    private static NotifierQueueClientImpl instance;
-
     private final int receiptQueueDelay = Integer.parseInt(System.getenv().getOrDefault("NOTIFIER_QUEUE_DELAY", "1"));
 
     private final QueueClient queueClient;
@@ -35,11 +33,15 @@ public class NotifierQueueClientImpl implements NotifierQueueClient {
     }
 
     public static NotifierQueueClientImpl getInstance() {
-        if (instance == null) {
-            instance = new NotifierQueueClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final NotifierQueueClientImpl INSTANCE = new NotifierQueueClientImpl();
     }
 
     /**
@@ -49,7 +51,6 @@ public class NotifierQueueClientImpl implements NotifierQueueClient {
      * @return response from the queue
      */
     public Response<SendMessageResult> sendMessageToQueue(String messageText) {
-
         return this.queueClient.sendMessageWithResponse(
                 messageText, Duration.of(receiptQueueDelay, ChronoUnit.SECONDS),
                 null, null, null);

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/PDVTokenizerClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/PDVTokenizerClientImpl.java
@@ -21,21 +21,12 @@ public class PDVTokenizerClientImpl implements PDVTokenizerClient {
 
     private static final String BASE_PATH = System.getenv().getOrDefault("PDV_TOKENIZER_BASE_PATH", "https://api.uat.tokenizer.pdv.pagopa.it/tokenizer/v1");
     private static final String SUBSCRIPTION_KEY = System.getenv().getOrDefault("PDV_TOKENIZER_SUBSCRIPTION_KEY", "");
-    private static final String SUBSCRIPTION_KEY_HEADER =  System.getenv().getOrDefault("TOKENIZER_APIM_HEADER_KEY", "x-api-key");
+    private static final String SUBSCRIPTION_KEY_HEADER = System.getenv().getOrDefault("TOKENIZER_APIM_HEADER_KEY", "x-api-key");
     private static final String SEARCH_TOKEN_ENDPOINT = System.getenv().getOrDefault("PDV_TOKENIZER_SEARCH_TOKEN_ENDPOINT", "/tokens/search");
     private static final String FIND_PII_ENDPOINT = System.getenv().getOrDefault("PDV_TOKENIZER_FIND_PII_ENDPOINT", "/tokens/%s/pii");
     private static final String CREATE_TOKEN_ENDPOINT = System.getenv().getOrDefault("PDV_TOKENIZER_CREATE_TOKEN_ENDPOINT", "/tokens");
 
     private final HttpClient client;
-
-    private static PDVTokenizerClientImpl instance;
-
-    public static PDVTokenizerClientImpl getInstance() {
-        if (instance == null) {
-            instance = new PDVTokenizerClientImpl();
-        }
-        return instance;
-    }
 
     private PDVTokenizerClientImpl() {
         this.client = HttpClient.newBuilder()
@@ -45,6 +36,18 @@ public class PDVTokenizerClientImpl implements PDVTokenizerClient {
 
     PDVTokenizerClientImpl(HttpClient client) {
         this.client = client;
+    }
+
+    public static PDVTokenizerClientImpl getInstance() {
+        return SingletonHelper.INSTANCE;
+    }
+
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final PDVTokenizerClientImpl INSTANCE = new PDVTokenizerClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
@@ -5,13 +5,17 @@ import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
-import com.azure.cosmos.util.CosmosPagedIterable;
+import com.azure.cosmos.models.SqlParameter;
+import com.azure.cosmos.models.SqlQuerySpec;
 import it.gov.pagopa.receipt.pdf.notifier.client.ReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.IOMessage;
+import it.gov.pagopa.receipt.pdf.notifier.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.notifier.exception.IoMessageNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.exception.ReceiptNotFoundException;
-import it.gov.pagopa.receipt.pdf.notifier.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.notifier.model.enumeration.UserType;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Client for the CosmosDB database
@@ -57,21 +61,20 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      */
     public Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
 
         //Build query
-        String query = "SELECT * FROM c WHERE c.eventId = " + "'" + eventId + "'";
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c WHERE c.eventId = @eventId",
+                List.of(new SqlParameter("@eventId", eventId))
+        );
 
         //Query the container
-        CosmosPagedIterable<Receipt> queryResponse = cosmosContainer
-                .queryItems(query, new CosmosQueryRequestOptions(), Receipt.class);
-
-        if (queryResponse.iterator().hasNext()) {
-            return queryResponse.iterator().next();
-        } else {
-            throw new ReceiptNotFoundException("Document not found in the defined container");
-        }
+        return cosmosContainer
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), Receipt.class)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ReceiptNotFoundException("Document not found in the defined container"));
     }
 
     /**
@@ -83,20 +86,27 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
      * @throws IoMessageNotFoundException in case no receipt has been found with the given eventId and user type
      */
     @Override
-    public IOMessage findIOMessageWithEventIdAndUserType(String eventId, UserType userType) throws IoMessageNotFoundException {
+    public IOMessage findIOMessageWithEventIdAndUserType(
+            String eventId,
+            UserType userType
+    ) throws IoMessageNotFoundException {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
         CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerMessageId);
 
         //Build query
-        String query = String.format("SELECT * FROM c WHERE c.eventId = '%s' AND c.userType = '%s'", eventId, userType);
+        SqlQuerySpec querySpec = new SqlQuerySpec(
+                "SELECT * FROM c WHERE c.eventId = @eventId AND c.userType = @userType ",
+                Arrays.asList(
+                        new SqlParameter("@eventId", eventId),
+                        new SqlParameter("@userType", userType)
+                )
+        );
 
         //Query the container
-        CosmosPagedIterable<IOMessage> queryResponse = cosmosContainer
-                .queryItems(query, new CosmosQueryRequestOptions(), IOMessage.class);
-
-        if (queryResponse.iterator().hasNext()) {
-            return queryResponse.iterator().next();
-        }
-        throw new IoMessageNotFoundException("Document not found in the defined container");
+        return cosmosContainer
+                .queryItems(querySpec, new CosmosQueryRequestOptions(), IOMessage.class)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IoMessageNotFoundException("Document not found in the defined container"));
     }
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
@@ -5,6 +5,7 @@ import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
 import it.gov.pagopa.receipt.pdf.notifier.client.ReceiptCosmosClient;
@@ -67,10 +68,12 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
                         new SqlParameter("@userType", userType)
                 )
         );
+        CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
+        options.setPartitionKey(new PartitionKey(eventId));
 
         //Query the container
         return cosmosContainer
-                .queryItems(querySpec, new CosmosQueryRequestOptions(), IOMessage.class)
+                .queryItems(querySpec, options, IOMessage.class)
                 .stream()
                 .findFirst()
                 .orElseThrow(() -> new IoMessageNotFoundException("Document not found in the defined container"));

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
@@ -22,23 +21,27 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
 
     private static ReceiptCosmosClientImpl instance;
 
-    private final String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
-    private final String containerMessageId = System.getenv("COSMOS_RECEIPT_MESSAGE_CONTAINER_NAME");
+    private final CosmosContainer ioMessageContainer;
 
-    private final CosmosClient cosmosClient;
-
+    @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
     private ReceiptCosmosClientImpl() {
         String azureKey = System.getenv("COSMOS_RECEIPT_KEY");
         String serviceEndpoint = System.getenv("COSMOS_RECEIPT_SERVICE_ENDPOINT");
 
-        this.cosmosClient = new CosmosClientBuilder()
+        String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
+        String containerMessageId = System.getenv("COSMOS_RECEIPT_MESSAGE_CONTAINER_NAME");
+
+        CosmosDatabase cosmosDatabase = new CosmosClientBuilder()
                 .endpoint(serviceEndpoint)
                 .key(azureKey)
-                .buildClient();
+                .buildClient()
+                .getDatabase(databaseId);
+
+        this.ioMessageContainer = cosmosDatabase.getContainer(containerMessageId);
     }
 
-    ReceiptCosmosClientImpl(CosmosClient cosmosClient) {
-        this.cosmosClient = cosmosClient;
+    ReceiptCosmosClientImpl(CosmosContainer ioMessageContainer) {
+        this.ioMessageContainer = ioMessageContainer;
     }
 
     public static ReceiptCosmosClientImpl getInstance() {
@@ -57,9 +60,6 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
             String eventId,
             UserType userType
     ) throws IoMessageNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerMessageId);
-
         //Build query
         SqlQuerySpec querySpec = new SqlQuerySpec(
                 "SELECT * FROM c WHERE c.eventId = @eventId AND c.userType = @userType ",
@@ -72,7 +72,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
         options.setPartitionKey(new PartitionKey(eventId));
 
         //Query the container
-        return cosmosContainer
+        return ioMessageContainer
                 .queryItems(querySpec, options, IOMessage.class)
                 .stream()
                 .findFirst()

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
@@ -19,8 +19,6 @@ import java.util.Arrays;
  */
 public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
 
-    private static ReceiptCosmosClientImpl instance;
-
     private final CosmosContainer ioMessageContainer;
 
     @SuppressWarnings("resource") // CosmosClient lifecycle == singleton lifecycle; never closed on purpose
@@ -45,11 +43,15 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     }
 
     public static ReceiptCosmosClientImpl getInstance() {
-        if (instance == null) {
-            instance = new ReceiptCosmosClientImpl();
-        }
+        return SingletonHelper.INSTANCE;
+    }
 
-        return instance;
+    /**
+     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
+     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     */
+    private static class SingletonHelper {
+        private static final ReceiptCosmosClientImpl INSTANCE = new ReceiptCosmosClientImpl();
     }
 
     /**

--- a/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImpl.java
@@ -9,23 +9,19 @@ import com.azure.cosmos.models.SqlParameter;
 import com.azure.cosmos.models.SqlQuerySpec;
 import it.gov.pagopa.receipt.pdf.notifier.client.ReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.IOMessage;
-import it.gov.pagopa.receipt.pdf.notifier.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.notifier.exception.IoMessageNotFoundException;
-import it.gov.pagopa.receipt.pdf.notifier.exception.ReceiptNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.model.enumeration.UserType;
 
 import java.util.Arrays;
-import java.util.List;
 
 /**
- * Client for the CosmosDB database
+ * {@inheritDoc}
  */
 public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
 
     private static ReceiptCosmosClientImpl instance;
 
     private final String databaseId = System.getenv("COSMOS_RECEIPT_DB_NAME");
-    private final String containerId = System.getenv("COSMOS_RECEIPT_CONTAINER_NAME");
     private final String containerMessageId = System.getenv("COSMOS_RECEIPT_MESSAGE_CONTAINER_NAME");
 
     private final CosmosClient cosmosClient;
@@ -53,37 +49,7 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     }
 
     /**
-     * Retrieve receipt document from CosmosDB database
-     *
-     * @param eventId Biz-event id
-     * @return receipt document
-     * @throws ReceiptNotFoundException in case no receipt has been found with the given idEvent
-     */
-    public Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException {
-        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
-        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
-
-        //Build query
-        SqlQuerySpec querySpec = new SqlQuerySpec(
-                "SELECT * FROM c WHERE c.eventId = @eventId",
-                List.of(new SqlParameter("@eventId", eventId))
-        );
-
-        //Query the container
-        return cosmosContainer
-                .queryItems(querySpec, new CosmosQueryRequestOptions(), Receipt.class)
-                .stream()
-                .findFirst()
-                .orElseThrow(() -> new ReceiptNotFoundException("Document not found in the defined container"));
-    }
-
-    /**
-     * Retrieve io message document from CosmosDB database with the provided event id and user type
-     *
-     * @param eventId  Receipt event id
-     * @param userType Recipient of the IO message
-     * @return io message document
-     * @throws IoMessageNotFoundException in case no receipt has been found with the given eventId and user type
+     * {@inheritDoc}
      */
     @Override
     public IOMessage findIOMessageWithEventIdAndUserType(

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImplTest.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.CartIOMessage;
 import it.gov.pagopa.receipt.pdf.notifier.exception.CartIoMessageNotFoundException;
@@ -19,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
@@ -56,10 +56,9 @@ class CartReceiptCosmosClientImplTest {
 
     @Test
     void findIOMessageWithCartIdAndEventIdAndUserTypeSuccessForPayer() {
-
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartIOMessage.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartIOMessage.class)))
                 .thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(mockIterator);
         when(mockIterator.hasNext()).thenReturn(true);
@@ -74,10 +73,9 @@ class CartReceiptCosmosClientImplTest {
 
     @Test
     void findIOMessageWithCartIdAndEventIdAndUserTypeSuccessForDebtor() {
-
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartIOMessage.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartIOMessage.class)))
                 .thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(mockIterator);
         when(mockIterator.hasNext()).thenReturn(true);
@@ -94,7 +92,7 @@ class CartReceiptCosmosClientImplTest {
     void getCartItemFail() {
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(CartIOMessage.class)))
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartIOMessage.class)))
                 .thenReturn(mockIterable);
         when(mockIterable.iterator()).thenReturn(mockIterator);
         when(mockIterator.hasNext()).thenReturn(false);

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImplTest.java
@@ -45,7 +45,7 @@ class CartReceiptCosmosClientImplTest {
         withEnvironmentVariables(
                 "COSMOS_RECEIPT_KEY", mockKey,
                 "COSMOS_RECEIPT_SERVICE_ENDPOINT", ""
-        ).execute(() -> assertThrows(IllegalArgumentException.class, CartReceiptCosmosClientImpl::getInstance));
+        ).execute(() -> assertThrows(ExceptionInInitializerError.class, CartReceiptCosmosClientImpl::getInstance));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/CartReceiptCosmosClientImplTest.java
@@ -1,8 +1,6 @@
 package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.CartIOMessage;
@@ -14,7 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,16 +30,11 @@ class CartReceiptCosmosClientImplTest {
     private static final String BIZ_EVENT_ID = "1";
 
     @Mock
-    private CosmosClient cosmosClientMock;
-
-    @Mock
-    private CosmosDatabase mockDatabase;
-    @Mock
     private CosmosContainer mockContainer;
     @Mock
     private CosmosPagedIterable<CartIOMessage> mockIterable;
     @Mock
-    private Iterator<CartIOMessage> mockIterator;
+    private Stream<CartIOMessage> mockStream;
 
     @InjectMocks
     private CartReceiptCosmosClientImpl sut;
@@ -56,13 +50,10 @@ class CartReceiptCosmosClientImplTest {
 
     @Test
     void findIOMessageWithCartIdAndEventIdAndUserTypeSuccessForPayer() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartIOMessage.class)))
                 .thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.hasNext()).thenReturn(true);
-        when(mockIterator.next()).thenReturn(new CartIOMessage());
+        when(mockIterable.stream()).thenReturn(mockStream);
+        when(mockStream.findFirst()).thenReturn(Optional.of(new CartIOMessage()));
 
         CartIOMessage result = assertDoesNotThrow(
                 () -> sut.findIOMessageWithCartIdAndEventIdAndUserType(CART_ID, null, UserType.PAYER)
@@ -73,13 +64,10 @@ class CartReceiptCosmosClientImplTest {
 
     @Test
     void findIOMessageWithCartIdAndEventIdAndUserTypeSuccessForDebtor() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartIOMessage.class)))
                 .thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.hasNext()).thenReturn(true);
-        when(mockIterator.next()).thenReturn(new CartIOMessage());
+        when(mockIterable.stream()).thenReturn(mockStream);
+        when(mockStream.findFirst()).thenReturn(Optional.of(new CartIOMessage()));
 
         CartIOMessage result = assertDoesNotThrow(
                 () -> sut.findIOMessageWithCartIdAndEventIdAndUserType(CART_ID, BIZ_EVENT_ID, UserType.DEBTOR)
@@ -90,12 +78,10 @@ class CartReceiptCosmosClientImplTest {
 
     @Test
     void getCartItemFail() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(CartIOMessage.class)))
                 .thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.hasNext()).thenReturn(false);
+        when(mockIterable.stream()).thenReturn(mockStream);
+        when(mockStream.findFirst()).thenReturn(Optional.empty());
 
         assertThrows(
                 CartIoMessageNotFoundException.class,

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/IOClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/IOClientImplTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.http.HttpClient;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -25,6 +27,14 @@ class IOClientImplTest {
     void setUp() {
         clientMock = mock(HttpClient.class);
         sut = spy(new IOClientImpl(clientMock));
+    }
+
+    @Test
+    void testSingletonError() {
+        IOClientImpl first = assertDoesNotThrow(IOClientImpl::getInstance);
+        IOClientImpl second = assertDoesNotThrow(IOClientImpl::getInstance);
+
+        assertEquals(first, second);
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierCartQueueClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierCartQueueClientImplTest.java
@@ -39,8 +39,7 @@ class NotifierCartQueueClientImplTest {
         withEnvironmentVariables(
                 "STORAGE_CONN_STRING", "DefaultEndpointsProtocol=https;AccountName=samplequeue;AccountKey=" + mockKey + ";EndpointSuffix=core.windows.net",
                 "NOTIFIER_CART_QUEUE_TOPIC", "validTopic"
-        ).execute(() -> assertDoesNotThrow(NotifierCartQueueClientImpl::getInstance)
-        );
+        ).execute(() -> assertDoesNotThrow(NotifierCartQueueClientImpl::getInstance));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierQueueClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/NotifierQueueClientImplTest.java
@@ -39,8 +39,7 @@ class NotifierQueueClientImplTest {
         withEnvironmentVariables(
                 "STORAGE_CONN_STRING", "DefaultEndpointsProtocol=https;AccountName=samplequeue;AccountKey=" + mockKey + ";EndpointSuffix=core.windows.net",
                 "NOTIFIER_QUEUE_TOPIC", "validTopic"
-        ).execute(() -> assertDoesNotThrow(NotifierQueueClientImpl::getInstance)
-        );
+        ).execute(() -> assertDoesNotThrow(NotifierQueueClientImpl::getInstance));
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/PDVTokenizerClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/PDVTokenizerClientImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.http.HttpClient;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
@@ -27,6 +28,14 @@ class PDVTokenizerClientImplTest {
     void setUp() {
         clientMock = mock(HttpClient.class);
         sut = spy(new PDVTokenizerClientImpl(clientMock));
+    }
+
+    @Test
+    void testSingletonError() {
+        PDVTokenizerClientImpl first = assertDoesNotThrow(PDVTokenizerClientImpl::getInstance);
+        PDVTokenizerClientImpl second = assertDoesNotThrow(PDVTokenizerClientImpl::getInstance);
+
+        assertEquals(first, second);
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
@@ -3,13 +3,10 @@ package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
-import com.azure.cosmos.models.FeedResponse;
 import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.IOMessage;
-import it.gov.pagopa.receipt.pdf.notifier.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.notifier.exception.IoMessageNotFoundException;
-import it.gov.pagopa.receipt.pdf.notifier.exception.ReceiptNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.model.enumeration.UserType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,13 +36,7 @@ class ReceiptCosmosClientImplTest {
     @Mock
     private CosmosContainer mockContainer;
     @Mock
-    private CosmosPagedIterable<Receipt> mockIterable;
-    @Mock
     private CosmosPagedIterable<IOMessage> mockIOMessageIterable;
-    @Mock
-    private Iterable<FeedResponse<Receipt>> mockReceiptIterableByPage;
-    @Mock
-    private Stream<Receipt> mockReceiptStream;
     @Mock
     private Stream<IOMessage> mockIOMessageStream;
 
@@ -59,37 +50,6 @@ class ReceiptCosmosClientImplTest {
                 "COSMOS_RECEIPT_KEY", mockKey,
                 "COSMOS_RECEIPT_SERVICE_ENDPOINT", ""
         ).execute(() -> assertThrows(IllegalArgumentException.class, ReceiptCosmosClientImpl::getInstance)
-        );
-    }
-
-    @Test
-    void getReceiptDocumentSuccess() {
-        String receiptId = "a valid receipt id";
-        Receipt receipt = new Receipt();
-        receipt.setId(receiptId);
-
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
-        when(mockIterable.stream()).thenReturn(mockReceiptStream);
-        when(mockReceiptStream.findFirst()).thenReturn(Optional.of(receipt));
-
-        Receipt response = assertDoesNotThrow(() -> sut.getReceiptDocument(receiptId));
-
-        assertNotNull(response);
-        assertEquals(receiptId, response.getId());
-    }
-
-    @Test
-    void getReceiptDocumentFailNotFound() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
-        when(mockIterable.stream()).thenReturn(mockReceiptStream);
-        when(mockReceiptStream.findFirst()).thenReturn(Optional.empty());
-
-        assertThrows(ReceiptNotFoundException.class,
-                () -> sut.getReceiptDocument("an invalid receipt id")
         );
     }
 
@@ -125,5 +85,4 @@ class ReceiptCosmosClientImplTest {
                 () -> sut.findIOMessageWithEventIdAndUserType("eventId", UserType.DEBTOR)
         );
     }
-
 }

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
@@ -3,39 +3,54 @@ package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.FeedResponse;
+import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.IOMessage;
 import it.gov.pagopa.receipt.pdf.notifier.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.notifier.exception.IoMessageNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.exception.ReceiptNotFoundException;
 import it.gov.pagopa.receipt.pdf.notifier.model.enumeration.UserType;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
 
+@ExtendWith(MockitoExtension.class)
 class ReceiptCosmosClientImplTest {
 
+    @Mock
     private CosmosClient cosmosClientMock;
-    private ReceiptCosmosClientImpl sut;
+    @Mock
+    private CosmosDatabase mockDatabase;
+    @Mock
+    private CosmosContainer mockContainer;
+    @Mock
+    private CosmosPagedIterable<Receipt> mockIterable;
+    @Mock
+    private CosmosPagedIterable<IOMessage> mockIOMessageIterable;
+    @Mock
+    private Iterable<FeedResponse<Receipt>> mockReceiptIterableByPage;
+    @Mock
+    private Stream<Receipt> mockReceiptStream;
+    @Mock
+    private Stream<IOMessage> mockIOMessageStream;
 
-    @BeforeEach
-    void setUp() {
-        cosmosClientMock = mock(CosmosClient.class);
-        sut = spy(new ReceiptCosmosClientImpl(cosmosClientMock));
-    }
+    @InjectMocks
+    private ReceiptCosmosClientImpl sut;
 
     @Test
     void testSingletonConnectionError() throws Exception {
@@ -50,21 +65,14 @@ class ReceiptCosmosClientImplTest {
     @Test
     void getReceiptDocumentSuccess() {
         String receiptId = "a valid receipt id";
-
-        CosmosDatabase mockDatabase = mock(CosmosDatabase.class);
-        CosmosContainer mockContainer = mock(CosmosContainer.class);
-        CosmosPagedIterable mockIterable = mock(CosmosPagedIterable.class);
-        Iterator<Receipt> mockIterator = mock(Iterator.class);
-
         Receipt receipt = new Receipt();
         receipt.setId(receiptId);
 
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.next()).thenReturn(receipt);
-        when(mockIterator.hasNext()).thenReturn(true);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockIterable.stream()).thenReturn(mockReceiptStream);
+        when(mockReceiptStream.findFirst()).thenReturn(Optional.of(receipt));
 
         Receipt response = assertDoesNotThrow(() -> sut.getReceiptDocument(receiptId));
 
@@ -74,38 +82,31 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void getReceiptDocumentFailNotFound() {
-        CosmosDatabase mockDatabase = mock(CosmosDatabase.class);
-        CosmosContainer mockContainer = mock(CosmosContainer.class);
-        CosmosPagedIterable mockIterable = mock(CosmosPagedIterable.class);
-        Iterator<Receipt> mockIterator = mock(Iterator.class);
-
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(Receipt.class))).thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.hasNext()).thenReturn(false);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(Receipt.class))).thenReturn(mockIterable);
+        when(mockIterable.stream()).thenReturn(mockReceiptStream);
+        when(mockReceiptStream.findFirst()).thenReturn(Optional.empty());
 
-
-        assertThrows(ReceiptNotFoundException.class, () -> sut.getReceiptDocument("an invalid receipt id"));
+        assertThrows(ReceiptNotFoundException.class,
+                () -> sut.getReceiptDocument("an invalid receipt id")
+        );
     }
 
     @Test
     void findIOMessageWithEventIdAndUserTypeSuccess() {
         String messageId = "messageId";
-
-        CosmosDatabase mockDatabase = mock(CosmosDatabase.class);
-        CosmosContainer mockContainer = mock(CosmosContainer.class);
-        CosmosPagedIterable mockIterable = mock(CosmosPagedIterable.class);
-        Iterator<IOMessage> mockIterator = mock(Iterator.class);
+        IOMessage ioMessage = IOMessage.builder().messageId(messageId).build();
 
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(IOMessage.class))).thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.next()).thenReturn(IOMessage.builder().messageId(messageId).build());
-        when(mockIterator.hasNext()).thenReturn(true);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(IOMessage.class)))
+                .thenReturn(mockIOMessageIterable);
+        when(mockIOMessageIterable.stream()).thenReturn(mockIOMessageStream);
+        when(mockIOMessageStream.findFirst()).thenReturn(Optional.of(ioMessage));
 
-        IOMessage response = assertDoesNotThrow(() -> sut.findIOMessageWithEventIdAndUserType("eventId", UserType.DEBTOR));
+        IOMessage response = assertDoesNotThrow(
+                () -> sut.findIOMessageWithEventIdAndUserType("eventId", UserType.DEBTOR));
 
         assertNotNull(response);
         assertEquals(messageId, response.getMessageId());
@@ -113,19 +114,16 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void findIOMessageWithEventIdAndUserTypeFailNotFound() {
-        CosmosDatabase mockDatabase = mock(CosmosDatabase.class);
-        CosmosContainer mockContainer = mock(CosmosContainer.class);
-        CosmosPagedIterable mockIterable = mock(CosmosPagedIterable.class);
-        Iterator<IOMessage> mockIterator = mock(Iterator.class);
-
         when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
         when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
-        when(mockContainer.queryItems(anyString(), any(), eq(IOMessage.class))).thenReturn(mockIterable);
-        when(mockIterable.iterator()).thenReturn(mockIterator);
-        when(mockIterator.hasNext()).thenReturn(false);
+        when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(IOMessage.class)))
+                .thenReturn(mockIOMessageIterable);
+        when(mockIOMessageIterable.stream()).thenReturn(mockIOMessageStream);
+        when(mockIOMessageStream.findFirst()).thenReturn(Optional.empty());
 
-
-        assertThrows(IoMessageNotFoundException.class, () -> sut.findIOMessageWithEventIdAndUserType("eventId", UserType.DEBTOR));
+        assertThrows(IoMessageNotFoundException.class,
+                () -> sut.findIOMessageWithEventIdAndUserType("eventId", UserType.DEBTOR)
+        );
     }
 
 }

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
@@ -1,8 +1,6 @@
 package it.gov.pagopa.receipt.pdf.notifier.client.impl;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
 import com.azure.cosmos.models.SqlQuerySpec;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.notifier.entity.message.IOMessage;
@@ -30,10 +28,6 @@ import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables
 class ReceiptCosmosClientImplTest {
 
     @Mock
-    private CosmosClient cosmosClientMock;
-    @Mock
-    private CosmosDatabase mockDatabase;
-    @Mock
     private CosmosContainer mockContainer;
     @Mock
     private CosmosPagedIterable<IOMessage> mockIOMessageIterable;
@@ -49,8 +43,7 @@ class ReceiptCosmosClientImplTest {
         withEnvironmentVariables(
                 "COSMOS_RECEIPT_KEY", mockKey,
                 "COSMOS_RECEIPT_SERVICE_ENDPOINT", ""
-        ).execute(() -> assertThrows(IllegalArgumentException.class, ReceiptCosmosClientImpl::getInstance)
-        );
+        ).execute(() -> assertThrows(IllegalArgumentException.class, ReceiptCosmosClientImpl::getInstance));
     }
 
     @Test
@@ -58,8 +51,6 @@ class ReceiptCosmosClientImplTest {
         String messageId = "messageId";
         IOMessage ioMessage = IOMessage.builder().messageId(messageId).build();
 
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(IOMessage.class)))
                 .thenReturn(mockIOMessageIterable);
         when(mockIOMessageIterable.stream()).thenReturn(mockIOMessageStream);
@@ -74,8 +65,6 @@ class ReceiptCosmosClientImplTest {
 
     @Test
     void findIOMessageWithEventIdAndUserTypeFailNotFound() {
-        when(cosmosClientMock.getDatabase(any())).thenReturn(mockDatabase);
-        when(mockDatabase.getContainer(any())).thenReturn(mockContainer);
         when(mockContainer.queryItems(any(SqlQuerySpec.class), any(), eq(IOMessage.class)))
                 .thenReturn(mockIOMessageIterable);
         when(mockIOMessageIterable.stream()).thenReturn(mockIOMessageStream);

--- a/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/notifier/client/impl/ReceiptCosmosClientImplTest.java
@@ -43,7 +43,7 @@ class ReceiptCosmosClientImplTest {
         withEnvironmentVariables(
                 "COSMOS_RECEIPT_KEY", mockKey,
                 "COSMOS_RECEIPT_SERVICE_ENDPOINT", ""
-        ).execute(() -> assertThrows(IllegalArgumentException.class, ReceiptCosmosClientImpl::getInstance));
+        ).execute(() -> assertThrows(ExceptionInInitializerError.class, ReceiptCosmosClientImpl::getInstance));
     }
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- build cosmos query with `SqlQuerySpec` instead of `String.format()`
- refactor CosmosClient in order to resolve CosmosContainer once in the constructor
- replaced the non-thread-safe lazy initialization in all clients with the **Bill Pugh singleton holder** pattern
- Suppressed the legitimate but intentional `resource` warning on the private constructors (`CosmosClient` lifecycle is bound to the singleton).
- set Partition Key in query option to avoid cross-partition query
- removed unused query
- fix tokenizer client in integrationt tests
- updated unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
[PAGOPA-3625](https://pagopa.atlassian.net/browse/PAGOPA-3625)
[PAGOPA-3667](https://pagopa.atlassian.net/browse/PAGOPA-3667)
<!--- Why is this change required? What problem does it solve? -->

- Allow Cosmos to leverage **query plan caching** by building query with `SqlQuerySpec`.
- The original clients re-resolved `CosmosDatabase` and `CosmosContainer` on every operation, duplicating boilerplate code going against the [official best practices for the Cosmos DB Java SDK v4](https://learn.microsoft.com/azure/cosmos-db/nosql/best-practice-java) (client and container references should be singletons for the whole application lifetime).
- The classic lazy singleton (`if (instance == null) instance = new ...`) is **not thread-safe**: under concurrent load an Azure Functions worker could build multiple Cosmos clients, each with its own TCP connection pool, wasting resources and potentially exceeding SNAT limits. The Bill Pugh holder pattern is thread-safe by JLS §12.4.2 guarantees, lazy, and has zero synchronization overhead on subsequent calls.
- setting Partition Key in query option of a paginated query allow Cosmos to **avoid cross-partition query**
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[PAGOPA-3625]: https://pagopa.atlassian.net/browse/PAGOPA-3625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ